### PR TITLE
Solving TypeError: RunShell._run() got an unexpected keyword argument 'bash_commands'

### DIFF
--- a/Gentopia/gentopia/tools/shell.py
+++ b/Gentopia/gentopia/tools/shell.py
@@ -131,7 +131,7 @@ def get_default_bash_process() -> BashProcess:
 
 
 class RunShellArgs(BaseModel):
-    bash_commands: str = Field(..., description="a sequence of shell commands")
+    commands: str = Field(..., description="a sequence of shell commands")
 
 
 class RunShell(BaseTool):


### PR DESCRIPTION
The following error occurred when trying to make the agent use bash commands.
![image](https://github.com/LittleYUYU/Gentopia-Mason/assets/36755503/379bfb05-82a8-4904-b5b7-97401f98f905)

`tools/shell.py` have an variable called `bash_commands` but used a variable called `commands` in `_run` method. So, updated the args variable to `commands` to resolve the issue.